### PR TITLE
Sim show profitability formulas rendering

### DIFF
--- a/app/helpers/simulations_helper.rb
+++ b/app/helpers/simulations_helper.rb
@@ -14,15 +14,15 @@ module SimulationsHelper
     "Assurance du crédit": 'credit_loan_insurance_total_amount'
   }.freeze
 
+  def convert_formula_element_to_corresponding_simulation_variable(formula_element)
+    FORMULA_ELEMENT_TO_CORRESPONDING_SIMULATION_VARIABLE[formula_element.to_sym]
+  end
+
   def errors_for(model, attribute)
     if model.errors[attribute].present?
       content_tag :span, class: 'error_explanation' do
         model.errors[attribute].join(', ')
       end
     end
-  end
-
-  def convert_formula_element_to_corresponding_simulation_variable(formula_element)
-    FORMULA_ELEMENT_TO_CORRESPONDING_SIMULATION_VARIABLE[formula_element.to_sym]
   end
 end

--- a/app/helpers/simulations_helper.rb
+++ b/app/helpers/simulations_helper.rb
@@ -6,4 +6,12 @@ module SimulationsHelper
       end
     end
   end
+
+  def tooltip_formula(formula_array)
+    formula_array.map!.with_index { |element, i| i.even? ? tooltip(element) : element }.join(' ')
+  end
+
+  def tooltip(element)
+    "#{element} <b>tooltiped</b>"
+  end
 end

--- a/app/helpers/simulations_helper.rb
+++ b/app/helpers/simulations_helper.rb
@@ -12,6 +12,14 @@ module SimulationsHelper
   end
 
   def tooltip(element)
-    "#{element} <b>tooltiped</b>"
+    tooltip = 'relative inline-block border-b border-dotted border-gray-400 group'
+    tooltiptext = 'absolute z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'
+
+    "<span class='#{tooltip}'>
+      #{element}
+      <span class='#{tooltiptext}'>
+        Tooltip text
+      </span>
+    </span>"
   end
 end

--- a/app/helpers/simulations_helper.rb
+++ b/app/helpers/simulations_helper.rb
@@ -2,8 +2,16 @@ module SimulationsHelper
   FORMULA_ELEMENT_TO_CORRESPONDING_SIMULATION_VARIABLE = {
     "test": 'hey oh',
     "Loyer annuel HC": 'house_rent_amount_per_year',
+    "Charges non récupérables": 'house_landlord_charges_amount_per_year',
+    "Taxe foncière": 'house_property_tax_amount_per_year',
+    "Assurance PNO": 'house_insurance_pno_amount_per_year',
+    "Assurance GLI": 'house_insurance_gli_amount_per_year',
+    "Frais de gestion(opt)": 'house_property_management_amount_per_year',
     "Prix d'achat": 'house_price_bought_amount',
-    "Frais de notaire": 'xxx'
+    "Frais de notaire": 'house_notarial_fees_amount',
+    "Eventuels travaux": 'house_first_works_amount',
+    "Intérêts du crédit": 'credit_loan_interest_total_amount',
+    "Assurance du crédit": 'credit_loan_insurance_total_amount'
   }.freeze
 
   def errors_for(model, attribute)

--- a/app/helpers/simulations_helper.rb
+++ b/app/helpers/simulations_helper.rb
@@ -22,24 +22,6 @@ module SimulationsHelper
     end
   end
 
-  def tooltip_formula(formula_elements_array)
-    formula_elements_array.map!.with_index do |formula_element, i|
-      i.even? ? tooltip(formula_element) : formula_element
-    end.join(' ')
-  end
-
-  def tooltip(formula_element)
-    tooltip = 'relative inline-block border-b border-dotted border-gray-400 group'
-    tooltiptext = 'absolute z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'
-
-    "<span class='#{tooltip}'>
-      #{formula_element}
-      <span class='#{tooltiptext}'>
-        <%= simulation.#{convert_formula_element_to_corresponding_simulation_variable(formula_element)} %>
-      </span>
-    </span>"
-  end
-
   def convert_formula_element_to_corresponding_simulation_variable(formula_element)
     FORMULA_ELEMENT_TO_CORRESPONDING_SIMULATION_VARIABLE[formula_element.to_sym]
   end

--- a/app/helpers/simulations_helper.rb
+++ b/app/helpers/simulations_helper.rb
@@ -1,4 +1,11 @@
 module SimulationsHelper
+  FORMULA_ELEMENT_TO_CORRESPONDING_SIMULATION_VARIABLE = {
+    "test": 'hey oh',
+    "Loyer annuel HC": 'house_rent_amount_per_year',
+    "Prix d'achat": 'house_price_bought_amount',
+    "Frais de notaire": 'xxx'
+  }.freeze
+
   def errors_for(model, attribute)
     if model.errors[attribute].present?
       content_tag :span, class: 'error_explanation' do
@@ -7,19 +14,25 @@ module SimulationsHelper
     end
   end
 
-  def tooltip_formula(formula_array)
-    formula_array.map!.with_index { |element, i| i.even? ? tooltip(element) : element }.join(' ')
+  def tooltip_formula(formula_elements_array)
+    formula_elements_array.map!.with_index do |formula_element, i|
+      i.even? ? tooltip(formula_element) : formula_element
+    end.join(' ')
   end
 
-  def tooltip(element)
+  def tooltip(formula_element)
     tooltip = 'relative inline-block border-b border-dotted border-gray-400 group'
     tooltiptext = 'absolute z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'
 
     "<span class='#{tooltip}'>
-      #{element}
+      #{formula_element}
       <span class='#{tooltiptext}'>
-        Tooltip text
+        <%= simulation.#{convert_formula_element_to_corresponding_simulation_variable(formula_element)} %>
       </span>
     </span>"
+  end
+
+  def convert_formula_element_to_corresponding_simulation_variable(formula_element)
+    FORMULA_ELEMENT_TO_CORRESPONDING_SIMULATION_VARIABLE[formula_element.to_sym]
   end
 end

--- a/app/javascript/plugins/simulation_show_profitability_dropdowns.js
+++ b/app/javascript/plugins/simulation_show_profitability_dropdowns.js
@@ -7,7 +7,7 @@ const initProfitabilityDropdowns = () => {
 
     const profitabilityRowsElements = Array.from(
       profitabilityRows.children
-    ).filter((child) => child.dataset.profitability);
+    ).filter((child) => child.dataset.profitabilityType);
 
     console.log(profitabilityRowsElements);
 

--- a/app/javascript/stylesheets/tailwind.config.js
+++ b/app/javascript/stylesheets/tailwind.config.js
@@ -9,7 +9,9 @@ module.exports = {
     extend: {},
   },
   variants: {
-    extend: {},
+    extend: {
+      visibility: ["hover", "group-hover"],
+    },
   },
   plugins: [],
 };

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -45,9 +45,17 @@ class Simulation < ApplicationRecord
     self.house_insurance_gli_percentage = HOUSE_STANDARD_INSURANCE_GLI_PERCENTAGE unless house_insurance_gli_percentage
   end
 
-  # ⚠ Remember to put conditional if tenant charges amount is specified
+  # Remember to put conditional if tenant charges amount is specified
+  def house_notarial_fees_amount
+    house_price_bought_amount * house_notarial_fees_percentage
+  end
+
+  def house_property_management_amount_per_year
+    house_rent_amount_per_year * house_property_management_cost_percentage
+  end
+
   def house_tenant_charges_amount_per_year
-    house_tenant_charges_percentage * house_rent_amount_per_year
+    house_rent_amount_per_year * house_tenant_charges_percentage
   end
 
   def house_landlord_charges_amount_per_year

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -69,6 +69,10 @@ class Simulation < ApplicationRecord
     (revenues - expenses) / divisor * 100
   end
 
+  def net_after_taxes_profitability
+    6.6
+  end
+
   def global_buying_operation_cost
     house_price_bought_amount * (1 + house_notarial_fees_percentage) + house_first_works_amount
   end

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -55,7 +55,7 @@ class Simulation < ApplicationRecord
   end
 
   def house_tenant_charges_amount_per_year
-    house_rent_amount_per_year * house_tenant_charges_percentage
+    house_total_charges_amount_per_year * house_tenant_charges_percentage
   end
 
   def house_landlord_charges_amount_per_year

--- a/app/views/simulations/_profitability_row_element.html.erb
+++ b/app/views/simulations/_profitability_row_element.html.erb
@@ -3,30 +3,23 @@
       name: "Rentabilité brute",
       definition: "Gross tbd",
       formula_quotient: ["Loyer annuel HC"],
-      formula_divisor: ["Prix d'achat", "+", "Frais de notaire", "+", "Eventuels travaux"],
-      dataset: 'data-profitability-type="gross"'
+      formula_divisor: ["Prix d'achat", "+", "Frais de notaire", "+", "Eventuels travaux"]
     }, 
     net: {
       name: "Rentabilité nette",
       definition: "Net tbd",
       formula_quotient: ["Loyer annuel HC", "-", "Charges non récupérables", "-", "Taxe foncière", "-", "Assurance PNO", "-", "Frais de gestion(opt)"],
-      formula_divisor: ["Prix d'achat", "+", "Frais de notaire", "+", "Eventuels travaux", "+", "Intérêts du crédit", "+", "Assurance du crédit"],
-      dataset: 'data-profitability-type="net"'
+      formula_divisor: ["Prix d'achat", "+", "Frais de notaire", "+", "Eventuels travaux", "+", "Intérêts du crédit", "+", "Assurance du crédit"]
     }, 
     net_after_taxes: {
       name: "Rentabilité nette après impôts",
       definition: "Net at tbd",
       formula_quotient: ["tbd"],
-      formula_divisor: ["tbd"],
-      dataset: 'data-profitability-type="netaftertaxes"'
+      formula_divisor: ["tbd"]
     }
   } %>
 
-<div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" 
-  <% if type == "gross" %> data-profitability-type="gross"
-  <% elsif type == "net" %> data-profitability-type="net" 
-  <% elsif type == "net_after_taxes" %> data-profitability-type="netaftertaxes" 
-  <% end %>>
+<div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" data-profitability-type="<%= type %>">
 
   <div class="flex justify-start items-center border">
     <p>

--- a/app/views/simulations/_profitability_row_element.html.erb
+++ b/app/views/simulations/_profitability_row_element.html.erb
@@ -1,0 +1,51 @@
+<% profitability = {
+    gross: {
+      name: "Rentabilité brute",
+      definition: "Gross tbd",
+      formula_quotient: "Loyer annuel HC",
+      formula_divisor: "Prix d'achat + Frais de notaire + Eventuels travaux"
+    }, 
+    net: {
+      name: "Rentabilité nette",
+      definition: "Net tbd",
+      formula_quotient: "Loyer annuel HC - Charges non récupérables - Taxe foncière - Assurance PNO - Assurance GLI - Frais de gestion(opt)",
+      formula_divisor: "Prix d'achat + Frais de notaire + Eventuels travaux + Intérêts et assurance crédit"
+    }, 
+    net_after_taxes: {
+      name: "Rentabilité nette après impôts",
+      definition: "Net at tbd",
+      formula_quotient: "tbd",
+      formula_divisor: "tbd"
+    }
+  } %>
+
+<div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" 
+  <% if type == "gross" %> data-profitability-type="gross"
+  <% elsif type == "net" %> data-profitability-type="net" 
+  <% elsif type == "net_after_taxes" %> data-profitability-type="netaftertaxes" 
+  <% end %>>
+
+  <div class="flex justify-start items-center border">
+    <p>
+      <%= sprintf("%20.1f", simulation.send("#{type}_profitability")) %>%
+    </p>
+  </div>
+  <div class="flex justify-start items-center col-span-2 border">
+    <%= profitability[type.to_sym][:name] %>
+  </div>
+  <div class="absolute right-px top-1/2 transform -translate-y-2/4">
+    <i class="fas fa-caret-down mx-1"></i>
+  </div>
+</div>
+<div>
+  <p class="text-xs my-2"><%= profitability[type.to_sym][:definition] %></p>
+  <div class="flex items-center my-4">
+    <p class="text-xs font-bold flex-shrink-0 mr-4">Formule :</p>
+    <div class="flex flex-col items-center mr-4">
+      <p class="text-xs"><%= profitability[type.to_sym][:formula_quotient] %></p>
+      <div class="border-t-2 w-full my-1"></div>
+      <p class="text-xs"><%= profitability[type.to_sym][:formula_divisor] %></p>
+    </div>
+    <p class="text-xs flex-shrink-0">* 100</p>
+  </div>
+</div>

--- a/app/views/simulations/_profitability_row_element.html.erb
+++ b/app/views/simulations/_profitability_row_element.html.erb
@@ -48,8 +48,8 @@
           <% if i.even? %>
           <span class="relative inline-block border-b border-dotted border-gray-400 group">
             <%= formula_element %>
-            <span class='absolute z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'>
-              <%= simulation.send(convert_formula_element_to_corresponding_simulation_variable(formula_element)) %>
+            <span class='absolute w-max z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'>
+              <%= simulation.send(convert_formula_element_to_corresponding_simulation_variable(formula_element)).to_s(:currency, unit: "€", format:"%n %u", delimiter: " ", precision: 0) %>
             </span>
           </span>
           <% else %>
@@ -65,8 +65,8 @@
           <% if i.even? %>
           <span class="relative inline-block border-b border-dotted border-gray-400 group">
             <%= formula_element %>
-            <span class='absolute z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'>
-              <%= simulation.send(convert_formula_element_to_corresponding_simulation_variable(formula_element)) %>
+            <span class='absolute w-max z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'>
+              <%= simulation.send(convert_formula_element_to_corresponding_simulation_variable(formula_element)).to_s(:currency, unit: "€", format:"%n %u", delimiter: " ", precision: 0) %>
             </span>
           </span>
           <% else %>

--- a/app/views/simulations/_profitability_row_element.html.erb
+++ b/app/views/simulations/_profitability_row_element.html.erb
@@ -19,6 +19,7 @@
     }
   } %>
 
+<!-- Plain rentability row -->
 <div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" data-profitability-type="<%= type %>">
 
   <div class="flex justify-start items-center border">
@@ -29,11 +30,12 @@
   <div class="flex justify-start items-center col-span-2 border">
     <%= profitability[type.to_sym][:name] %>
   </div>
-  <div class="absolute right-px top-1/2 transform -translate-y-2/4">
+  <div class="absolute right-px top-1/2 transform -translate-y-1/2">
     <i class="fas fa-caret-down mx-1"></i>
   </div>
 </div>
 
+<!-- Expanded rentability row -->
 <div>
   <p class="text-xs my-2"><%= profitability[type.to_sym][:definition] %></p>
 
@@ -41,11 +43,11 @@
     <p class="text-xs font-bold flex-shrink-0 mr-4">Formule :</p>
     <div class="flex flex-col items-center mr-4">
       <p class="text-xs">
-        <%= tooltip_formula(profitability[type.to_sym][:formula_quotient]) %>
+        <%= tooltip_formula(profitability[type.to_sym][:formula_quotient]).html_safe %>
       </p>
       <div class="border-t-2 w-full my-1"></div>
       <p class="text-xs">
-        <%= tooltip_formula(profitability[type.to_sym][:formula_divisor]) %>
+        <%= tooltip_formula(profitability[type.to_sym][:formula_divisor]).html_safe %>
       </p>
     </div>
 

--- a/app/views/simulations/_profitability_row_element.html.erb
+++ b/app/views/simulations/_profitability_row_element.html.erb
@@ -8,7 +8,7 @@
     net: {
       name: "Rentabilité nette",
       definition: "Net tbd",
-      formula_quotient: ["Loyer annuel HC", "-", "Charges non récupérables", "-", "Taxe foncière", "-", "Assurance PNO", "-", "Frais de gestion(opt)"],
+      formula_quotient: ["Loyer annuel HC", "-", "Charges non récupérables", "-", "Taxe foncière", "-", "Assurance GLI", "-", "Assurance PNO","-", "Frais de gestion(opt)"],
       formula_divisor: ["Prix d'achat", "+", "Frais de notaire", "+", "Eventuels travaux", "+", "Intérêts du crédit", "+", "Assurance du crédit"]
     }, 
     net_after_taxes: {

--- a/app/views/simulations/_profitability_row_element.html.erb
+++ b/app/views/simulations/_profitability_row_element.html.erb
@@ -2,20 +2,23 @@
     gross: {
       name: "Rentabilité brute",
       definition: "Gross tbd",
-      formula_quotient: "Loyer annuel HC",
-      formula_divisor: "Prix d'achat + Frais de notaire + Eventuels travaux"
+      formula_quotient: ["Loyer annuel HC"],
+      formula_divisor: ["Prix d'achat", "+", "Frais de notaire", "+", "Eventuels travaux"],
+      dataset: 'data-profitability-type="gross"'
     }, 
     net: {
       name: "Rentabilité nette",
       definition: "Net tbd",
-      formula_quotient: "Loyer annuel HC - Charges non récupérables - Taxe foncière - Assurance PNO - Assurance GLI - Frais de gestion(opt)",
-      formula_divisor: "Prix d'achat + Frais de notaire + Eventuels travaux + Intérêts et assurance crédit"
+      formula_quotient: ["Loyer annuel HC", "-", "Charges non récupérables", "-", "Taxe foncière", "-", "Assurance PNO", "-", "Frais de gestion(opt)"],
+      formula_divisor: ["Prix d'achat", "+", "Frais de notaire", "+", "Eventuels travaux", "+", "Intérêts du crédit", "+", "Assurance du crédit"],
+      dataset: 'data-profitability-type="net"'
     }, 
     net_after_taxes: {
       name: "Rentabilité nette après impôts",
       definition: "Net at tbd",
-      formula_quotient: "tbd",
-      formula_divisor: "tbd"
+      formula_quotient: ["tbd"],
+      formula_divisor: ["tbd"],
+      dataset: 'data-profitability-type="netaftertaxes"'
     }
   } %>
 
@@ -37,15 +40,22 @@
     <i class="fas fa-caret-down mx-1"></i>
   </div>
 </div>
+
 <div>
   <p class="text-xs my-2"><%= profitability[type.to_sym][:definition] %></p>
+
   <div class="flex items-center my-4">
     <p class="text-xs font-bold flex-shrink-0 mr-4">Formule :</p>
     <div class="flex flex-col items-center mr-4">
-      <p class="text-xs"><%= profitability[type.to_sym][:formula_quotient] %></p>
+      <p class="text-xs">
+        <%= tooltip_formula(profitability[type.to_sym][:formula_quotient]) %>
+      </p>
       <div class="border-t-2 w-full my-1"></div>
-      <p class="text-xs"><%= profitability[type.to_sym][:formula_divisor] %></p>
+      <p class="text-xs">
+        <%= tooltip_formula(profitability[type.to_sym][:formula_divisor]) %>
+      </p>
     </div>
+
     <p class="text-xs flex-shrink-0">* 100</p>
   </div>
 </div>

--- a/app/views/simulations/_profitability_row_element.html.erb
+++ b/app/views/simulations/_profitability_row_element.html.erb
@@ -14,8 +14,8 @@
     net_after_taxes: {
       name: "Rentabilité nette après impôts",
       definition: "Net at tbd",
-      formula_quotient: ["tbd"],
-      formula_divisor: ["tbd"]
+      formula_quotient: ["Loyer annuel HC"],
+      formula_divisor: ["Prix d'achat", "+", "Frais de notaire", "+", "Eventuels travaux"]
     }
   } %>
 
@@ -42,13 +42,39 @@
   <div class="flex items-center my-4">
     <p class="text-xs font-bold flex-shrink-0 mr-4">Formule :</p>
     <div class="flex flex-col items-center mr-4">
+
       <p class="text-xs">
-        <%= tooltip_formula(profitability[type.to_sym][:formula_quotient]).html_safe %>
+        <% profitability[type.to_sym][:formula_quotient].map.with_index do |formula_element, i| %>
+          <% if i.even? %>
+          <span class="relative inline-block border-b border-dotted border-gray-400 group">
+            <%= formula_element %>
+            <span class='absolute z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'>
+              <%= simulation.send(convert_formula_element_to_corresponding_simulation_variable(formula_element)) %>
+            </span>
+          </span>
+          <% else %>
+            <%= formula_element %>
+          <% end %>
+        <% end %>
       </p>
+
       <div class="border-t-2 w-full my-1"></div>
+
       <p class="text-xs">
-        <%= tooltip_formula(profitability[type.to_sym][:formula_divisor]).html_safe %>
+        <% profitability[type.to_sym][:formula_divisor].map.with_index do |formula_element, i| %>
+          <% if i.even? %>
+          <span class="relative inline-block border-b border-dotted border-gray-400 group">
+            <%= formula_element %>
+            <span class='absolute z-10 bottom-full left-1/2 transform -translate-x-1/2 bg-gray-600 text-white text-center px-5 rounded-md invisible group-hover:visible'>
+              <%= simulation.send(convert_formula_element_to_corresponding_simulation_variable(formula_element)) %>
+            </span>
+          </span>
+          <% else %>
+            <%= formula_element %>
+          <% end %>
+        <% end %>
       </p>
+
     </div>
 
     <p class="text-xs flex-shrink-0">* 100</p>

--- a/app/views/simulations/show.html.erb
+++ b/app/views/simulations/show.html.erb
@@ -3,7 +3,7 @@
   <!-- Back to index button for users -->
   <% if current_user %>
     <div class="flex justify-start mt-4 text-sm">
-      <%= link_to "Retour aux simulations", simulations_path, class: "bg-opacity-0 text-gray-400 border border-1 border-gray-400 px-2 py-1 rounded cursor-pointer" %>
+      <%= link_to "Retour aux simulations", simulations_path, class: "bg-opacity-0 text-gray-600 border border-1 border-gray-600 px-2 py-1 rounded cursor-pointer" %>
     </div>
   <% end %>
 

--- a/app/views/simulations/show.html.erb
+++ b/app/views/simulations/show.html.erb
@@ -30,77 +30,10 @@
     <h2 class="font-bold">Rentabilités :</h2>
     
     <div id="profitabilities-rows">
-      <!-- Gross profitability -->
-      <div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" data-profitability="gross">
-        <div class="flex justify-start items-center border">
-          <p>
-            <% if @simulation.gross_profitability > 0 %>
-              + <%= sprintf("%20.1f", @simulation.gross_profitability) %>%
-            <% elsif @simulation.gross_profitability < 0 %>
-              - <%= sprintf("%20.1f", @simulation.gross_profitability) %>%
-            <% elsif @simulation.gross_profitability == 0 %>
-              <%= sprintf("%20.1f", @simulation.gross_profitability) %>%
-            <% end %>
-          </p>
-        </div>
-        <div class="flex justify-start items-center col-span-2 border">
-          <p>Rentabilité brute</p>
-        </div>
-        <div class="absolute right-px top-1/2 transform -translate-y-2/4">
-          <i class="fas fa-caret-down mx-1"></i>
-        </div>
-      </div>
-      <div>
-        <p class="text-xs my-2">Explanation of what it corresponds</p>
-        <div class="flex items-center my-4">
-          <p class="text-xs font-bold flex-shrink-0 mr-4">Formule :</p>
-          <div class="flex flex-col items-center mr-4">
-            <p class="text-xs">Loyer annuel HC</p>
-            <div class="border-t-2 w-full my-1"></div>
-            <p class="text-xs">Prix d'achat + Frais de notaire + Eventuels travaux</p>
-          </div>
-          <p class="text-xs flex-shrink-0">* 100</p>
-        </div>
-      </div>
-  
-  
-      <!-- Net profitability -->
-      <div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" data-profitability="net">
-        <div class="flex justify-start items-center border">
-          <p>
-            <% if @simulation.net_profitability > 0 %>
-              + <%= sprintf("%20.1f", @simulation.net_profitability) %>%
-            <% elsif @simulation.net_profitability < 0 %>
-              - <%= sprintf("%20.1f", @simulation.net_profitability) %>%
-            <% elsif @simulation.net_profitability == 0 %>
-              <%= sprintf("%20.1f", @simulation.net_profitability) %>%
-            <% end %>
-          </p>
-        </div>
-        <div class="flex justify-start items-center col-span-2 border">
-          <p>Rentabilité nette</p>
-        </div>
-        <div class="absolute right-px top-1/2 transform -translate-y-2/4">
-          <i class="fas fa-caret-down mx-1"></i>
-        </div>
-      </div>
-      <p class="text-xs my-4"><span class="font-bold">Formule : </span>((Loyer annuel HC - Charges non récupérables - Taxe foncière - Assurance PNO - Assurance GLI - Frais de gestion(opt)) / (Prix d'achat + Frais de notaire + Eventuels travaux + Intérêts et assurance crédit)) * 100 </p>
-  
-  
-      <!-- Net after taxes profitability -->
-      <div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" data-profitability="netaftertaxes">
-        <div class="flex justify-start items-center border">
-          <p>+ 4.5%</p>
-        </div>
-        <div class="flex justify-start items-center col-span-2 border">
-          <p>Rentabilité nette après impôts</p>
-        </div>
-        <div class="absolute right-px top-1/2 transform -translate-y-2/4">
-          <i class="fas fa-caret-down mx-1"></i>
-        </div>
-      </div>
+      <%= render 'profitability_row_element', simulation: @simulation, type: "gross" %>
+      <%= render 'profitability_row_element', simulation: @simulation, type: "net" %>
+      <%= render 'profitability_row_element', simulation: @simulation, type: "net_after_taxes" %>
     </div>
-
 
   </div>
 

--- a/app/views/simulations/show.html.erb
+++ b/app/views/simulations/show.html.erb
@@ -50,7 +50,18 @@
           <i class="fas fa-caret-down mx-1"></i>
         </div>
       </div>
-      <p class="text-xs my-4"><span class="font-bold">Formule : </span>(Loyer annuel HC / (Prix d'achat + Frais de notaire + Eventuels travaux)) * 100 </p>
+      <div>
+        <p class="text-xs my-2">Explanation of what it corresponds</p>
+        <div class="flex items-center my-4">
+          <p class="text-xs font-bold flex-shrink-0 mr-4">Formule :</p>
+          <div class="flex flex-col items-center mr-4">
+            <p class="text-xs">Loyer annuel HC</p>
+            <div class="border-t-2 w-full my-1"></div>
+            <p class="text-xs">Prix d'achat + Frais de notaire + Eventuels travaux</p>
+          </div>
+          <p class="text-xs flex-shrink-0">* 100</p>
+        </div>
+      </div>
   
   
       <!-- Net profitability -->

--- a/app/views/simulations/show.html.erb
+++ b/app/views/simulations/show.html.erb
@@ -54,7 +54,7 @@
   
   
       <!-- Net profitability -->
-      <div class="grid grid-cols-3 cursor-pointer" style="min-height: 36px;" data-profitability="net">
+      <div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" data-profitability="net">
         <div class="flex justify-start items-center border">
           <p>
             <% if @simulation.net_profitability > 0 %>
@@ -69,17 +69,23 @@
         <div class="flex justify-start items-center col-span-2 border">
           <p>Rentabilité nette</p>
         </div>
+        <div class="absolute right-px top-1/2 transform -translate-y-2/4">
+          <i class="fas fa-caret-down mx-1"></i>
+        </div>
       </div>
       <p class="text-xs my-4"><span class="font-bold">Formule : </span>((Loyer annuel HC - Charges non récupérables - Taxe foncière - Assurance PNO - Assurance GLI - Frais de gestion(opt)) / (Prix d'achat + Frais de notaire + Eventuels travaux + Intérêts et assurance crédit)) * 100 </p>
   
   
       <!-- Net after taxes profitability -->
-      <div class="grid grid-cols-3 cursor-pointer" style="min-height: 36px;" data-profitability="netaftertaxes">
+      <div class="grid grid-cols-3 cursor-pointer relative" style="min-height: 36px;" data-profitability="netaftertaxes">
         <div class="flex justify-start items-center border">
           <p>+ 4.5%</p>
         </div>
         <div class="flex justify-start items-center col-span-2 border">
           <p>Rentabilité nette après impôts</p>
+        </div>
+        <div class="absolute right-px top-1/2 transform -translate-y-2/4">
+          <i class="fas fa-caret-down mx-1"></i>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Created profitability formulas for gross and net profitabilities and rendered them

Added the details of the profitabilities amounts displayed in simulation show.
These profitabilites now have formulas showing the user what they are composed of and what number is behind each calculation component when the user hover over it.

E.g. 
![image](https://user-images.githubusercontent.com/74139731/119565032-bba1d500-bda9-11eb-9b81-47e898cca510.png)


This was also the opportunity for me to ask my first question on Stack Overflow!([https://stackoverflow.com/questions/67693586/rails-is-escaping-erb-lines-in-a-view-using-html-safe](url))
