### PR TITLE
Implementation of Income Taxes Formulas logic

### DIFF
--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -5,7 +5,9 @@ class SimulationsController < ApplicationController
     @simulations = current_user.simulations
   end
 
-  def show; end
+  def show
+    raise
+  end
 
   def update
     @simulation.attributes = simulation_params

--- a/app/models/concerns/income_taxes_base_formulas.rb
+++ b/app/models/concerns/income_taxes_base_formulas.rb
@@ -12,6 +12,9 @@ module IncomeTaxesBaseFormulas
   }
   LUMP_SUMP_ALLOWANCE = 0.1
 
+  REAL_REGIMEN_DEDUCTIBLE_EXPENSES_FOR_YEAR_TWO = %i[house_landlord_charges_amount_per_year
+                                                     house_property_management_amount_per_year house_insurance_gli_amount_per_year house_insurance_pno_amount_per_year house_property_tax_amount_per_year credit_loan_cumulative_interests_paid_for_year_two credit_loan_insurance_amount_per_year].freeze
+
   def self.calc_income_tax_amount_per_year(args = {}, property_income = 0)
     taxable_amount = calc_taxable_amount(args, property_income)
     current_year = Date.today.year

--- a/app/models/concerns/income_taxes_formulas.rb
+++ b/app/models/concerns/income_taxes_formulas.rb
@@ -5,12 +5,12 @@ module IncomeTaxesFormulas
   include(NueFormulas)
   include(LmnpFormulas)
 
-  def calc_income_tax_total_amount_per_year(args = {})
+  def calc_income_tax_total_amount_for_year_two(args = {})
     case args[:fiscal_status]
     when 'Vide'
-      NueFormulas.calc_income_tax_amount_per_year(args)
+      NueFormulas.calc_income_tax_amount_for_year_two(args)
     when 'LMNP'
-      LmnpFormulas.calc_income_tax_amount_per_year(args)
+      LmnpFormulas.calc_income_tax_amount_for_year_two(args)
     end
   end
 
@@ -18,10 +18,10 @@ module IncomeTaxesFormulas
     IncomeTaxesBaseFormulas.calc_income_tax_amount_per_year(args)
   end
 
-  def calc_income_tax_incurred_by_property_income_amount_per_year(args = {})
+  def calc_income_tax_incurred_by_taxable_property_income_amount_for_year_two(args = {})
     income_tax_base_amount_per_year = calc_income_tax_base_amount_per_year(args)
-    income_tax_with_property_income_amount_per_year = calc_income_tax_total_amount_per_year(args)
+    income_tax_with_taxable_property_income_amount_for_year_two = calc_income_tax_total_amount_for_year_two(args)
 
-    income_tax_with_property_income_amount_per_year - income_tax_base_amount_per_year
+    income_tax_with_taxable_property_income_amount_for_year_two - income_tax_base_amount_per_year
   end
 end

--- a/app/models/concerns/nue_formulas.rb
+++ b/app/models/concerns/nue_formulas.rb
@@ -3,21 +3,22 @@
 module NueFormulas
   include(IncomeTaxesBaseFormulas)
 
-  DEDUCTIBLE_EXPENSES = %i[house_first_works_amount].freeze
   PROPERTY_INCOME_DEDUCTION_PERCENTAGE = 0.3
 
-  def self.calc_property_income(args = {})
+  def self.calc_taxable_property_income_for_year_two(args = {})
     case args[:fiscal_regimen]
     when 'Réel'
-      deductible_expenses = DEDUCTIBLE_EXPENSES.map { |expense| args[expense] }.sum
+      deductible_expenses = IncomeTaxesBaseFormulas::REAL_REGIMEN_DEDUCTIBLE_EXPENSES_FOR_YEAR_TWO.map do |expense|
+        args[expense] || 0
+      end.sum
       args[:house_rent_amount_per_year] - deductible_expenses
     when 'Forfait'
       args[:house_rent_amount_per_year] * (1 - PROPERTY_INCOME_DEDUCTION_PERCENTAGE)
     end
   end
 
-  def self.calc_income_tax_amount_per_year(args = {})
-    property_income = calc_property_income(args)
-    IncomeTaxesBaseFormulas.calc_income_tax_amount_per_year(args, property_income)
+  def self.calc_income_tax_amount_for_year_two(args = {})
+    taxable_property_income = calc_taxable_property_income_for_year_two(args)
+    IncomeTaxesBaseFormulas.calc_income_tax_amount_per_year(args, taxable_property_income)
   end
 end

--- a/app/models/simulation.rb
+++ b/app/models/simulation.rb
@@ -127,22 +127,33 @@ class Simulation < ApplicationRecord
     - ppmt(credit_loan_interest_rate_per_month, payment_period, credit_loan_duration_in_months, credit_loan_amount)
   end
 
-  def credit_loan_cumulative_principal_paid_for_month(payment_period)
+  def credit_loan_cumulative_principal_paid_since_beginning_for_month(payment_period)
     - cumprinc(credit_loan_interest_rate_per_month, credit_loan_duration_in_months, credit_loan_amount, 1,
                payment_period)
   end
 
-  def credit_loan_cumulative_interests_paid_for_month(payment_period)
+  def credit_loan_cumulative_interests_paid_since_beginning_for_month(payment_period)
     - cumipmt(credit_loan_interest_rate_per_month, credit_loan_duration_in_months, credit_loan_amount, 1,
               payment_period)
   end
 
+  def credit_loan_cumulative_interests_paid_for_year(payment_period)
+    start_per = (payment_period * 12) + 1
+    end_per = (payment_period + 1) * 12
+    - cumipmt(credit_loan_interest_rate_per_month, credit_loan_duration_in_months, credit_loan_amount, start_per,
+              end_per)
+  end
+
+  def credit_loan_cumulative_interests_paid_for_year_two
+    credit_loan_cumulative_interests_paid_for_year(2)
+  end
+
   def credit_loan_interest_total_amount
-    credit_loan_cumulative_interests_paid_for_month(credit_loan_duration_in_months)
+    credit_loan_cumulative_interests_paid_since_beginning_for_month(credit_loan_duration_in_months)
   end
 
   def credit_loan_remaining_principal_to_pay_for_month(payment_period)
-    credit_loan_amount - credit_loan_cumulative_principal_paid_for_month(payment_period)
+    credit_loan_amount - credit_loan_cumulative_principal_paid_since_beginning_for_month(payment_period)
   end
 
   # Credit_loan insurance
@@ -152,7 +163,11 @@ class Simulation < ApplicationRecord
   end
 
   def credit_loan_insurance_amount_per_month
-    credit_loan_insurance_percentage_per_month * credit_loan_amount
+    credit_loan_amount * credit_loan_insurance_percentage_per_month
+  end
+
+  def credit_loan_insurance_amount_per_year
+    credit_loan_amount * credit_loan_insurance_percentage_per_year
   end
 
   def credit_loan_insurance_total_amount
@@ -161,16 +176,17 @@ class Simulation < ApplicationRecord
 
   # Taxes
 
-  def fiscal_income_tax_incurred_by_property_income_amount_per_year
-    calc_income_tax_incurred_by_property_income_amount_per_year({
-                                                                  fiscal_status: fiscal_status,
-                                                                  fiscal_regimen: fiscal_regimen,
-                                                                  fiscal_revenues_p1: fiscal_revenues_p1,
-                                                                  fiscal_revenues_p2: fiscal_revenues_p2,
-                                                                  fiscal_nb_parts: fiscal_nb_parts,
-                                                                  house_rent_amount_per_year: house_rent_amount_per_year,
-                                                                  house_first_works_amount: house_first_works_amount
-                                                                })
+  def fiscal_income_tax_incurred_by_taxable_property_income_amount_per_year
+    calc_income_tax_incurred_by_taxable_property_income_amount_per_year({
+                                                                          fiscal_status: fiscal_status,
+                                                                          fiscal_regimen: fiscal_regimen,
+                                                                          fiscal_revenues_p1: fiscal_revenues_p1,
+                                                                          fiscal_revenues_p2: fiscal_revenues_p2,
+                                                                          fiscal_nb_parts: fiscal_nb_parts,
+                                                                          house_rent_amount_per_year: house_rent_amount_per_year,
+                                                                          house_first_works_amount: house_first_works_amount,
+                                                                          credit_loan_cumulative_interests_paid_for_year_two: credit_loan_cumulative_interests_paid_for_year_two
+                                                                        })
   end
 
   def fiscal_income_tax_total_amount_per_year

--- a/app/views/simulations/show.html.erb
+++ b/app/views/simulations/show.html.erb
@@ -14,7 +14,7 @@
     </div>
   <% end %>
 
-  <!-- Introduction text -->
+  <!-- Introduction text --> 
   <div class="mt-8 p-2 bg-green-100 flex items-center">
     <p class="">Plusieurs coûts (taux de crédit, assurances, etc) sont calculés automatiquement sur la base d’indicateurs nationaux.
       <br>Vous pouvez les personnaliser plus bas.</p>
@@ -75,9 +75,9 @@
     <div class="flex flex-col mb-4">
       <p>IPMT 12 = <%= @simulation.credit_loan_interest_cost_for_month(12) %> OK</p>
       <p>PPMT 12 = <%= @simulation.credit_loan_principal_repayment_for_month(12) %> OK</p>
-      <p>CUMPRINC 12 = <%= @simulation.credit_loan_cumulative_principal_paid_for_month(12) %> OK</p>
+      <p>CUMPRINC_since_beginning 12 = <%= @simulation.credit_loan_cumulative_principal_paid_since_beginning_for_month(12) %> OK</p>
       <p>Credit_loan amount - CUMPRINC 12 = <%= @simulation.credit_loan_remaining_principal_to_pay_for_month(12) %> OK</p>
-      <p>CUMIPMT 12 = <%= @simulation.credit_loan_cumulative_interests_paid_for_month(12) %></p>
+      <p>CUMIPMT_since_beginning 12 = <%= @simulation.credit_loan_cumulative_interests_paid_since_beginning_for_month(12) %></p>
     </div>
     <p class="font-bold">Total credit costs</p>
     <div class="flex flex-col mb-4">


### PR DESCRIPTION
# Established all the logic for calculating income taxes with associated taxable property income

Made the code organized by splitting responsibilities along files.
- **Simulation model** = calls a method from IncomeTaxesFormulas module with a hash of variables (house_rent_per_year_amount, etc)
- **IncomeTaxesFormulas module** = handles the request and redirects to corresponding fiscal_status module (ie NueFormulas for "Vide" regimen), it can then calculates base income tax, income tax incurred by the investment and final income tax
- **Nue/Lmnp/...Formulas** = generates their corresponding taxable property income and income tax with this new income
- **IncomeTaxesBaseFormulas module** = makes all IncomeTaxes modules inherit from its generic methods and constants

Next PR will be RSpec tests in order to test our code

Mth0158